### PR TITLE
Added an option to build a static linked version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ ifeq ($(DEBUG),1)
 FLAG_DEBUG=-DENABLE_DEBUG=1
 endif
 
+# allow make STATIC=1 to create a static linked executable
+ifeq ($(STATIC),1)
+LDFLAGS= -static -static-libgcc -static-libstdc++ -pthread -lrt -laio
+endif
+
 all:$(BIN)
 
 # link the object files into the target

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Debug build (enables debugging output with d\_printf() function):
 
 You may need to `make clean` first if you already built diskspd without debugging turned on
 
+Static linking (enables static libraries for binary portability):
+
+        make STATIC=1
+
 ### Usage ###
 
         diskspd [OPTIONS...] FILE [FILE...]


### PR DESCRIPTION
Added an option to build a static linked version of diskspd to make it easier to build a single version and run it on various versions of Linux.  Based this new option on the make DEBUG=1 option to be consistent.