### PR TITLE
Fix Wreturn-type that occurs when building with assertions off

### DIFF
--- a/src/options.cc
+++ b/src/options.cc
@@ -75,6 +75,7 @@ namespace diskspd
 			default:
 				assert(!"Invalid size specifier!");
 		 }
+		return 0;
 	}
 
 	unsigned long long Options::byte_size_from_arg(const char * curr_arg, size_t block_size) {


### PR DESCRIPTION
This occurs in non-DEBUG builds.
return 0 seems to be the current convention used for unexpected failures.