### PR TITLE
Report more meaningful error on stat failure.

### DIFF
--- a/src/profile.cc
+++ b/src/profile.cc
@@ -320,7 +320,7 @@ namespace diskspd
 			struct stat buf = {0};
 			int err = stat(target->path.c_str(), &buf);
 			if (err && errno != ENOENT) {
-				fprintf(stderr, "Unexpected error when statting target!\n");
+				fprintf(stderr, "Unexpected error '%d: %s' when statting %s!\n", errno, strerror(errno), target->path.c_str());
 #ifdef ENABLE_DEBUG
 				perror("stat");
 #endif

--- a/src/sys_info.cc
+++ b/src/sys_info.cc
@@ -176,7 +176,7 @@ namespace diskspd {
 			dev_path = "/dev/" + str;
 			int err = stat(dev_path.c_str(), &dev_stat);
 			if (err) {
-				fprintf(stderr, "Unexpected error '%d: %s' when statting device!\n", errno, strerror(errno));
+				fprintf(stderr, "Unexpected error '%d: %s' when statting %s!\n", errno, strerror(errno), dev_path.c_str());
 				perror("stat");
 				exit(1);
 			}

--- a/src/sys_info.cc
+++ b/src/sys_info.cc
@@ -176,7 +176,7 @@ namespace diskspd {
 			dev_path = "/dev/" + str;
 			int err = stat(dev_path.c_str(), &dev_stat);
 			if (err) {
-				fprintf(stderr, "Unexpected error when statting device!\n");
+				fprintf(stderr, "Unexpected error '%d: %s' when statting device!\n", errno, strerror(errno));
 				perror("stat");
 				exit(1);
 			}


### PR DESCRIPTION
Instead of failing with `Unexpected error when statting device!` a failure will now look like `Unexpected error '2: No such file or directory' when statting /dev/loop0!` or `Unexpected error '13: Permission denied' when statting /root/diskspd/test/centos1.dat!`.